### PR TITLE
feat: replace Lucide icons with Phosphor icons across multiple compon…

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -2,7 +2,7 @@
 
 import { motion } from "motion/react"
 import { BackgroundBeams } from "../../components/ui/background-beams"
-import { ArrowLeft } from "lucide-react"
+import { ArrowLeft } from "@phosphor-icons/react"
 import Link from "next/link"
 
 export default function AuthLayout({
@@ -25,7 +25,7 @@ export default function AuthLayout({
           href="/"
           className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-white/80 backdrop-blur-lg border border-white/30 hover:bg-white/90 hover:border-white/50 transition-all duration-300 group shadow-lg"
         >
-          <ArrowLeft className="w-6 h-6 text-electric-slate-700 group-hover:text-electric-slate-900 transition-colors" />
+          <ArrowLeft size={24} weight="duotone" className="text-electric-slate-700 group-hover:text-electric-slate-900 transition-colors" />
         </Link>
       </motion.div>
 

--- a/app/components/HeroSection.tsx
+++ b/app/components/HeroSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { motion } from "motion/react"
-import { ArrowRight } from "lucide-react"
+import { ArrowRight } from "@phosphor-icons/react"
 import { BackgroundBeams } from "../../components/ui/background-beams"
 import TrueFocus from "../../components/TrueFocus"
 import { CryptoIcons } from "./CryptoIcons"
@@ -98,7 +98,7 @@ export function HeroSection() {
             className="bg-cyber-mint-600 hover:bg-cyber-mint-700 text-white px-8 py-4 sm:px-12 sm:py-6 text-lg sm:text-xl font-semibold rounded-full cursor-pointer transition-colors duration-300 w-full max-w-sm sm:max-w-none sm:w-auto group flex items-center justify-center"
           >
             Get Started
-            <ArrowRight className="w-5 h-5 ml-3 group-hover:translate-x-1 transition-transform duration-200" />
+            <ArrowRight size={20} weight="duotone" className="ml-3 group-hover:translate-x-1 transition-transform duration-200" />
           </motion.button>
 
         </motion.div>

--- a/components/AuthErrorBoundary.tsx
+++ b/components/AuthErrorBoundary.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { Component, ReactNode } from 'react'
-import { AlertTriangle, RefreshCw, Home } from 'lucide-react'
+import { Warning, ArrowClockwise, House } from '@phosphor-icons/react'
 import Link from 'next/link'
 import { AuthService } from '../lib/auth'
 
@@ -67,7 +67,7 @@ export class AuthErrorBoundary extends Component<Props, State> {
         <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
           <div className="max-w-md w-full bg-white rounded-lg shadow-lg p-8 text-center">
             <div className="mb-6">
-              <AlertTriangle className="w-16 h-16 text-red-500 mx-auto mb-4" />
+              <Warning size={64} weight="duotone" className="text-red-500 mx-auto mb-4" />
               <h1 className="text-2xl font-bold text-gray-900 mb-2">
                 Authentication Error
               </h1>
@@ -90,7 +90,7 @@ export class AuthErrorBoundary extends Component<Props, State> {
                 onClick={this.handleRetry}
                 className="w-full flex items-center justify-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
               >
-                <RefreshCw className="w-4 h-4 mr-2" />
+                <ArrowClockwise size={16} weight="duotone" className="mr-2" />
                 Try Again
               </button>
 
@@ -98,7 +98,7 @@ export class AuthErrorBoundary extends Component<Props, State> {
                 onClick={this.handleClearAuth}
                 className="w-full flex items-center justify-center px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors"
               >
-                <Home className="w-4 h-4 mr-2" />
+                <House size={16} weight="duotone" className="mr-2" />
                 Clear Session & Go Home
               </button>
 

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { motion } from "motion/react"
-import { Eye, EyeOff } from "lucide-react"
+import { Eye, EyeSlash } from "@phosphor-icons/react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 import { Label } from "./label"
@@ -72,9 +72,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             whileTap={{ scale: 0.95 }}
           >
             {showPassword ? (
-              <EyeOff className="h-5 w-5" />
+              <EyeSlash size={20} weight="duotone" />
             ) : (
-              <Eye className="h-5 w-5" />
+              <Eye size={20} weight="duotone" />
             )}
           </motion.button>
         )}

--- a/components/ui/navbar-1.tsx
+++ b/components/ui/navbar-1.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { useState } from "react"
 import { motion, AnimatePresence } from "motion/react"
-import { Menu, X, User } from "lucide-react"
+import { List, X, User } from "@phosphor-icons/react"
 import { useAuth } from "../../hooks/useAuth"
 import Link from "next/link"
 
@@ -68,7 +68,7 @@ const Navbar1 = () => {
               className="flex items-center space-x-2 px-3 py-2 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors"
               whileHover={{ scale: 1.05 }}
             >
-              <User className="w-4 h-4" />
+              <User size={16} weight="duotone" />
               <span className="text-sm font-medium">{user.name}</span>
             </motion.button>
 
@@ -121,7 +121,7 @@ const Navbar1 = () => {
 
         {/* Mobile Menu Button */}
         <motion.button className="md:hidden flex items-center" onClick={toggleMenu} whileTap={{ scale: 0.9 }}>
-          <Menu className="h-6 w-6 text-electric-slate-800" />
+          <List size={24} weight="duotone" className="text-electric-slate-800" />
         </motion.button>
       </div>
 
@@ -143,7 +143,7 @@ const Navbar1 = () => {
               animate={{ opacity: 1 }}
               transition={{ delay: 0.2 }}
             >
-              <X className="h-6 w-6 text-electric-slate-800" />
+              <X size={24} weight="duotone" className="text-electric-slate-800" />
             </motion.button>
             <div className="flex flex-col space-y-6">
               {["Features", "Pricing", "About", "Contact"].map((item, i) => (

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-slot": "^1.2.3",
@@ -19,7 +20,6 @@
         "cookie": "^1.0.2",
         "framer-motion": "^12.23.12",
         "gsap": "^3.13.0",
-        "lucide-react": "^0.544.0",
         "motion": "^12.23.12",
         "next": "15.5.2",
         "ogl": "^1.0.11",
@@ -977,6 +977,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
+      "integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -4928,15 +4941,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "0.544.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
-      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
@@ -20,7 +21,6 @@
     "cookie": "^1.0.2",
     "framer-motion": "^12.23.12",
     "gsap": "^3.13.0",
-    "lucide-react": "^0.544.0",
     "motion": "^12.23.12",
     "next": "15.5.2",
     "ogl": "^1.0.11",


### PR DESCRIPTION
…ents

- Update imports in AuthLayout, HeroSection, AuthErrorBoundary, Input, and Navbar1 to use Phosphor icons
- Adjust icon sizes and weights for consistency and improved visual appeal
- Remove Lucide icons from package dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated all UI icons to Phosphor for a consistent, duotone look and clearer sizing.
  * Refreshed icons in authentication screens, hero section, error states, password visibility toggle, and navigation (desktop and mobile).
  * No changes to behavior or navigation; visual update only.

* **Chores**
  * Replaced the previous icon library with Phosphor Icons in dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->