### PR TITLE
feat(integration): SOL currency, dashboard live totals, devnet support

### DIFF
--- a/features/donation/components/DonationForm.tsx
+++ b/features/donation/components/DonationForm.tsx
@@ -118,6 +118,7 @@ export function DonationForm({ wallet }: DonationFormProps) {
           message: message || undefined,
           tx_hash: result.txHash,
           address_from: result.fromAddress,
+          currency: currencyLabel,
         },
       })
       setState('success')

--- a/features/donation/services/donation.ts
+++ b/features/donation/services/donation.ts
@@ -13,6 +13,7 @@ export interface TransactionSubmit {
   message?: string
   tx_hash: string
   address_from: string
+  currency: string
 }
 
 export class DonationService {

--- a/features/transactions/hooks/useDashboardMetrics.ts
+++ b/features/transactions/hooks/useDashboardMetrics.ts
@@ -92,27 +92,27 @@ export function useDashboardMetrics(streamerId: string | undefined): DashboardMe
     const weekStart = new Date(todayStart.getTime() - 6 * 24 * 60 * 60 * 1000)
     const previousWeekStart = new Date(weekStart.getTime() - 7 * 24 * 60 * 60 * 1000)
 
-    // Today's total (confirmed only)
+    // Today's total
     const todayTotal = transactions
       .filter(
-        (t) => t.status === 'confirmed' && t.createdAt >= todayStart
+        (t) => t.status !== 'failed' && t.createdAt >= todayStart
       )
       .reduce((sum, t) => sum + t.amount, 0)
 
-    // Last hour total (confirmed only)
+    // Last hour total
     const lastHourTotal = transactions
       .filter(
-        (t) => t.status === 'confirmed' && t.createdAt >= oneHourAgo
+        (t) => t.status !== 'failed' && t.createdAt >= oneHourAgo
       )
       .reduce((sum, t) => sum + t.amount, 0)
 
     // Total donations count
-    const totalDonations = transactions.filter((t) => t.status === 'confirmed').length
+    const totalDonations = transactions.filter((t) => t.status !== 'failed').length
 
     // This week's total
     const weeklyTotal = transactions
       .filter(
-        (t) => t.status === 'confirmed' && t.createdAt >= weekStart
+        (t) => t.status !== 'failed' && t.createdAt >= weekStart
       )
       .reduce((sum, t) => sum + t.amount, 0)
 
@@ -120,7 +120,7 @@ export function useDashboardMetrics(streamerId: string | undefined): DashboardMe
     const previousWeekTotal = transactions
       .filter(
         (t) =>
-          t.status === 'confirmed' &&
+          t.status !== 'failed' &&
           t.createdAt >= previousWeekStart &&
           t.createdAt < weekStart
       )
@@ -190,7 +190,7 @@ function calculateDailyData(transactions: Transaction[], weekStart: Date): Daily
 
   // Aggregate transactions by day
   transactions
-    .filter((t) => t.status === 'confirmed' && t.createdAt >= weekStart)
+    .filter((t) => t.status !== 'failed' && t.createdAt >= weekStart)
     .forEach((t) => {
       const dayName = dayNames[t.createdAt.getDay()]
       const existing = dailyMap.get(dayName) || { value: 0, messages: 0 }
@@ -217,7 +217,7 @@ function calculateTopDonors(transactions: Transaction[]): TopDonor[] {
 
   // Sum up donations by address
   transactions
-    .filter((t) => t.status === 'confirmed')
+    .filter((t) => t.status !== 'failed')
     .forEach((t) => {
       const current = donorTotals.get(t.addressFrom) || 0
       donorTotals.set(t.addressFrom, current + t.amount)

--- a/features/transactions/hooks/useDashboardMetrics.ts
+++ b/features/transactions/hooks/useDashboardMetrics.ts
@@ -51,19 +51,6 @@ export interface DashboardMetrics {
   error: Error | null
 }
 
-// Helper to get currency from wallet provider (simplified)
-function getCurrencyFromAddress(address: string): string {
-  // Ethereum addresses start with 0x and are 42 characters
-  if (address.startsWith('0x') && address.length === 42) {
-    return 'ETH'
-  }
-  // Solana addresses are base58 encoded and typically 32-44 characters
-  if (address.length >= 32 && address.length <= 44 && !address.startsWith('0x')) {
-    return 'SOL'
-  }
-  return 'CRYPTO'
-}
-
 // Helper to truncate address for display
 function truncateAddress(address: string): string {
   if (address.length <= 10) return address
@@ -149,7 +136,7 @@ export function useDashboardMetrics(streamerId: string | undefined): DashboardMe
         id: t.id,
         username: `@${truncateAddress(t.addressFrom)}`,
         amount: t.amount,
-        currency: getCurrencyFromAddress(t.addressFrom),
+        currency: t.currency,
         message: t.message || undefined,
         timestamp: t.createdAt,
         status: t.status,

--- a/lib/backend-types.ts
+++ b/lib/backend-types.ts
@@ -200,6 +200,7 @@ export interface BackendTransaction {
   amount: number                // Transaction amount
   tx_hash: string               // Blockchain transaction hash
   status: TransactionStatus     // Transaction status
+  currency: string              // e.g. "ETH", "SOL", "USDT", "USDC"
   message: string               // Donation message
   created_at: string            // ISO timestamp
   updated_at: string            // ISO timestamp
@@ -279,6 +280,7 @@ export interface Transaction {
   amount: number
   txHash: string
   status: TransactionStatus
+  currency: string              // e.g. "ETH", "SOL", "USDT", "USDC"
   message: string
   createdAt: Date
   updatedAt: Date
@@ -293,6 +295,7 @@ export function transformBackendTransactionToFrontend(backendTransaction: Backen
     amount: backendTransaction.amount,
     txHash: backendTransaction.tx_hash,
     status: backendTransaction.status,
+    currency: backendTransaction.currency,
     message: backendTransaction.message,
     createdAt: new Date(backendTransaction.created_at),
     updatedAt: new Date(backendTransaction.updated_at)


### PR DESCRIPTION
## Summary
- Pass `currency` field on transaction submission (ETH for MetaMask, SOL for Phantom) — previously omitted, causing all Phantom donations to be stored as ETH
- Fix `useDashboardMetrics` filters from `status === 'confirmed'` to `status !== 'failed'` — backend creates transactions as `pending` with no update path, so dashboard totals were always zero
- Devnet support already wired via `NEXT_PUBLIC_SOLANA_CLUSTER` env var — set to `devnet` in local `.env` for testing

## Depends on
Backend PR: https://github.com/Dnreikronos/givememoney.fun-backend/pull/41 (adds SOL as accepted currency)

## Test plan
- [ ] Connect Phantom wallet (devnet), send a test donation — verify `currency: "SOL"` recorded in backend
- [ ] Connect MetaMask wallet (Sepolia), send a test donation — verify `currency: "ETH"` recorded
- [ ] Dashboard shows non-zero totals after a donation
- [ ] OBS alert fires after successful donation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Donations now capture and store currency (e.g., ETH or SOL) with each transaction.

* **Improvements**
  * Dashboard metrics broadened to include all non-failed transactions, giving a more complete view of donation activity.
  * Recent donation listings and summaries now surface reported currency directly for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->