### PR TITLE
feat(prod-prep): navigation, onboarding flow, and UX fixes

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { MetricsCards, WeeklyStatsCard, TopDonorsCard, RecentDonationsFeed } from '@/features/dashboard'
 import { useAuth } from '@/features/auth'
 import { useDashboardMetrics } from '@/features/transactions'
@@ -98,12 +99,26 @@ export default function DashboardPage() {
   }
 
   return (
-    <motion.main
-      className="dashboard-grid"
-      variants={containerVariants}
-      initial="hidden"
-      animate="show"
-    >
+    <>
+      {!isAuthLoading && user && user.wallet === null && (
+        <div className="mx-4 mt-4 border border-cyber-mint-200 bg-cyber-mint-50 rounded-lg px-4 py-3 flex items-center justify-between gap-4">
+          <span className="text-sm text-electric-slate-700">
+            <span className="font-semibold">⚡ Complete seu perfil</span> — Conecte sua carteira para começar a receber doações.
+          </span>
+          <Link
+            href="/layout/qrcode"
+            className="text-sm font-medium text-cyber-mint-600 hover:text-cyber-mint-700 shrink-0 transition-colors"
+          >
+            Conectar agora →
+          </Link>
+        </div>
+      )}
+      <motion.main
+        className="dashboard-grid"
+        variants={containerVariants}
+        initial="hidden"
+        animate="show"
+      >
       {/* Primary Metrics Section (40% visual space) */}
       <motion.div className="card-large" variants={itemVariants}>
         {isMetricsLoading ? (
@@ -150,5 +165,6 @@ export default function DashboardPage() {
         )}
       </motion.div>
     </motion.main>
+    </>
   )
 }

--- a/components/layout/DashboardSidebar.tsx
+++ b/components/layout/DashboardSidebar.tsx
@@ -8,8 +8,6 @@ import {
   CurrencyCircleDollar,
   Monitor,
   QrCode,
-  User,
-  GearSix,
   SignOut,
   CaretUpDown,
 } from '@phosphor-icons/react'
@@ -197,21 +195,6 @@ export function DashboardSidebar() {
                         {user.email}
                       </p>
                     )}
-                  </div>
-                  <DropdownMenuSeparator className="bg-electric-slate-100" />
-                  <div className="py-1">
-                    <DropdownMenuItem asChild className="cursor-pointer gap-2 px-3 py-1.5 text-electric-slate-600">
-                      <Link href="/profile">
-                        <User size={15} weight="duotone" />
-                        <span className="text-[13px]">Meu Perfil</span>
-                      </Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild className="cursor-pointer gap-2 px-3 py-1.5 text-electric-slate-600">
-                      <Link href="/settings">
-                        <GearSix size={15} weight="duotone" />
-                        <span className="text-[13px]">Configurações</span>
-                      </Link>
-                    </DropdownMenuItem>
                   </div>
                   <DropdownMenuSeparator className="bg-electric-slate-100" />
                   <div className="py-1">

--- a/components/layout/FloatingNavbar.tsx
+++ b/components/layout/FloatingNavbar.tsx
@@ -216,20 +216,6 @@ export function FloatingNavbar({ isLive = false }: FloatingNavbarProps) {
                       exit={{ opacity: 0, y: 10 }}
                       className="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50"
                     >
-                      <a
-                        href="/profile"
-                        className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors cursor-pointer"
-                        onClick={() => setShowUserMenu(false)}
-                      >
-                        Meu Perfil
-                      </a>
-                      <a
-                        href="/settings"
-                        className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors cursor-pointer"
-                        onClick={() => setShowUserMenu(false)}
-                      >
-                        Configurações
-                      </a>
                       <button
                         onClick={() => {
                           logout()

--- a/components/ui/navbar-1.tsx
+++ b/components/ui/navbar-1.tsx
@@ -44,8 +44,7 @@ const Navbar1 = () => {
             </Link>
             <Link
               href="/register"
-              className="px-4 py-2 text-sm font-medium text-white rounded-lg transition-colors"
-              style={{ backgroundColor: "#00A896" }}
+              className="px-4 py-2 text-sm font-medium text-white bg-cyber-mint-500 hover:bg-cyber-mint-600 rounded-lg transition-colors"
             >
               Get Started
             </Link>

--- a/components/ui/navbar-1.tsx
+++ b/components/ui/navbar-1.tsx
@@ -33,6 +33,23 @@ const Navbar1 = () => {
               GiveMeMoney
             </span>
           </Link>
+
+          {/* Nav actions */}
+          <div className="flex items-center gap-3">
+            <Link
+              href="/login"
+              className="px-4 py-2 text-sm font-medium text-gray-700 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              Sign In
+            </Link>
+            <Link
+              href="/register"
+              className="px-4 py-2 text-sm font-medium text-white rounded-lg transition-colors"
+              style={{ backgroundColor: "#00A896" }}
+            >
+              Get Started
+            </Link>
+          </div>
         </nav>
       </div>
     </header>

--- a/features/auth/components/RegisterForm.tsx
+++ b/features/auth/components/RegisterForm.tsx
@@ -29,8 +29,8 @@ export function RegisterForm() {
     try {
       await AuthService.registerWithEmail(data.name, data.email, data.password, data.confirmPassword)
 
-      // Redirect to dashboard on successful registration
-      window.location.href = '/dashboard'
+      // Redirect new users to wallet setup before the dashboard
+      window.location.href = '/layout/qrcode'
     } catch (error) {
       setError(error instanceof Error ? error.message : 'Registration failed. Please try again.')
     } finally {


### PR DESCRIPTION
## Summary

- **Navbar:** adds Sign In (outline) and Get Started (Cyber Mint) buttons to the landing page — users can now navigate to auth from `/`
- **Register flow:** redirects new users to `/layout/qrcode` after registration instead of the empty dashboard, guiding wallet setup
- **Dashboard:** shows a wallet-setup banner when `user.wallet === null` so users with no wallet connected know what to do next
- **Sidebar:** removes dead `/profile` and `/settings` links from the user dropdown — only "Sair" remains

## Test plan

- [ ] Open `/` → navbar shows Sign In and Get Started links
- [ ] Click Sign In → arrives at `/login`
- [ ] Click Get Started → arrives at `/register`
- [ ] Complete registration → redirected to `/layout/qrcode`
- [ ] Login with account that has no wallet → banner visible at top of dashboard with "Conectar agora →" link
- [ ] Login with account that has a wallet → banner not shown
- [ ] Click user avatar in sidebar → dropdown shows only "Sair"
- [ ] `npx next build` passes with no TypeScript errors